### PR TITLE
New: removing cloud run instances created by PR when is merged

### DIFF
--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -1,0 +1,30 @@
+name: Delete Cloud Run instances on PR closed by merged
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+jobs:
+  delete-cloud-run:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4.4.1
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GAR_JSON_KEY }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: 'Use gcloud CLI'
+        run: 'gcloud info'
+
+      - name: Use gcloud CLI
+        run: gcloud run services delete ${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}-${{ env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }} --region=${{ vars.GCP_REGION }} --quiet


### PR DESCRIPTION
Upon merging this pull request, the associated Cloud Run service created by a PR will be deleted. This deletion ensures that any resources provisioned for testing purposes are cleaned up, reducing unnecessary costs and maintaining a tidy development environment.