### PR TITLE
docs: update cuenta unica faq content

### DIFF
--- a/app/api/faqs/route.ts
+++ b/app/api/faqs/route.ts
@@ -6,52 +6,44 @@ export async function GET() {
       id: 1,
       question: '¿Cómo puedo restaurar mi contraseña?',
       answer: `
-        <p>Para restaurar su contraseña, siga estos pasos:</p>
+        <p>
+          Si olvidó su contraseña, puede recuperar el acceso desde la página de inicio
+          de sesión de <strong>Cuenta Única Ciudadana</strong>.
+        </p>
         <ol>
-    <li>
-      <strong>Acceder a la página de inicio de sesión:</strong><br />
-      Diríjase a la página de inicio de sesión:
-      <a href="https://mi.cuentaunica.gob.do/ui/login" target="_blank" rel="noopener noreferrer">
-        https://mi.cuentaunica.gob.do/ui/login
-      </a>
-    </li>
-
-    <li>
-      <strong>Iniciar el proceso de recuperación:</strong><br />
-      En la pantalla de <strong>Iniciar sesión</strong>, haga clic en el enlace
-      <strong>“¿Olvidó su contraseña?”</strong>.
-    </li>
-
-    <li>
-      <strong>Ingresar el correo electrónico:</strong><br />
-      Se mostrará la pantalla <strong>“Recuperar su cuenta”</strong>. Ingrese el correo electrónico con el que se registró y haga clic en <strong>“Continuar”</strong>.<br />
-      <em>El sistema enviará un correo electrónico con un código de recuperación.</em>
-    </li>
-
-    <li>
-      <strong>Revisar el correo electrónico:</strong><br />
-      Revise su bandeja de entrada. Recibirá un correo con el asunto similar a
-      <strong>“Recupere el acceso a su Cuenta Única”</strong>, donde encontrará el <strong>código de recuperación</strong>.<br />
-      Si no lo recibe, revise la carpeta <strong>Spam / No deseados</strong> y verifique que el correo ingresado sea el mismo con el que se registró.
-    </li>
-
-    <li>
-      <strong>Ingresar el código de recuperación:</strong><br />
-      Regrese a la pantalla <strong>“Recuperar su cuenta”</strong>, introduzca el <strong>código de recuperación</strong> y haga clic en <strong>“Continuar”</strong>.<br />
-      Si el código expiró o no llegó, utilice la opción <strong>“Reenviar código”</strong>.
-    </li>
-
-    <li>
-      <strong>Confirmación de recuperación:</strong><br />
-      El sistema validará el código ingresado y mostrará un mensaje indicando que la cuenta ha sido recuperada exitosamente.<br />
-      <em>Se le notificará que debe cambiar su contraseña o configurar un método alternativo de inicio de sesión dentro de un tiempo determinado.</em>
-    </li>
-
-    <li>
-      <strong>Cambiar la contraseña:</strong><br />
-      En la pantalla <strong>Configuraciones de la Cuenta</strong>, diríjase a <strong>“Cambiar Contraseña”</strong>, ingrese la nueva contraseña y haga clic en <strong>“Guardar”</strong>.
-    </li>
-  </ol>
+          <li>
+            <strong>Acceda al inicio de sesión:</strong><br />
+            Entre a
+            <a href="https://mi.cuentaunica.gob.do/ui/login" target="_blank" rel="noopener noreferrer">
+              https://mi.cuentaunica.gob.do/ui/login
+            </a>.
+          </li>
+          <li>
+            <strong>Inicie la recuperación:</strong><br />
+            Seleccione la opción <strong>“¿Olvidó su contraseña?”</strong>.
+          </li>
+          <li>
+            <strong>Indique su correo electrónico:</strong><br />
+            Escriba el correo electrónico asociado a su cuenta y presione
+            <strong>“Continuar”</strong>. El sistema enviará un código de recuperación.
+          </li>
+          <li>
+            <strong>Revise el mensaje recibido:</strong><br />
+            Busque el correo de recuperación en su bandeja de entrada. Si no aparece,
+            revise <strong>Spam</strong> o <strong>Correo no deseado</strong>, y confirme
+            que usó el correo electrónico correcto.
+          </li>
+          <li>
+            <strong>Valide el código:</strong><br />
+            Introduzca el código en la pantalla de recuperación. Si el código expiró o no
+            llegó, utilice la opción <strong>“Reenviar código”</strong>.
+          </li>
+          <li>
+            <strong>Actualice su contraseña:</strong><br />
+            Cuando el sistema valide el código, defina una contraseña nueva y guarde los
+            cambios. Use una contraseña única, segura y que no utilice en otros servicios.
+          </li>
+        </ol>
       `,
       images: [
         '/faqs/1/1-step-1.png',
@@ -64,79 +56,100 @@ export async function GET() {
     },
     {
       id: 2,
-      question: '¿Cómo puedo re-crear mi cuenta?',
+      question: '¿Cómo puedo crear mi cuenta nuevamente?',
       answer: `
-        <p>Si necesita volver a crear su cuenta:</p>
-     <ol>
-    <li>
-      <strong>Verificar el estado de la cuenta anterior:</strong><br />
-      Asegúrese de que su cuenta anterior haya sido eliminada o desactivada antes de iniciar el proceso de registro nuevamente.
-    </li>
-
-    <li>
-      <strong>Acceder a la página de registro:</strong><br />
-      Diríjase a la página de registro en el siguiente enlace:
-      <a href="https://registro.cuentaunica.gob.do" target="_blank" rel="noopener noreferrer">
-        https://registro.cuentaunica.gob.do
-      </a>
-    </li>
-
-    <li>
-      <strong>Completar el formulario de registro:</strong><br />
-      Ingrese correctamente sus datos personales en el formulario de registro.
-    </li>
-
-    <li>
-      <strong>Verificar el correo electrónico:</strong><br />
-      Una vez enviado el formulario, revise su correo electrónico y siga las instrucciones para
-      <strong>verificar su cuenta</strong> y activar el acceso a la nueva cuenta.
-    </li>
-  </ol>
+        <p>
+          La <strong>Cuenta Única Ciudadana</strong> está asociada a su identidad. En
+          condiciones normales no necesita crear varias cuentas: debe recuperar el acceso
+          a la cuenta existente o completar el registro si todavía no lo ha finalizado.
+        </p>
+        <ol>
+          <li>
+            <strong>Si ya tenía una cuenta:</strong><br />
+            Intente iniciar sesión con su cédula de identidad y electoral o con el correo
+            electrónico asociado. Si no recuerda la contraseña, use la opción
+            <strong>“¿Olvidó su contraseña?”</strong>.
+          </li>
+          <li>
+            <strong>Si no completó el registro:</strong><br />
+            Entre a
+            <a href="https://registro.cuentaunica.gob.do" target="_blank" rel="noopener noreferrer">
+              https://registro.cuentaunica.gob.do
+            </a>
+            y siga los pasos de verificación de identidad, creación de contraseña y
+            confirmación del correo electrónico.
+          </li>
+          <li>
+            <strong>Si el sistema indica que ya existe una cuenta:</strong><br />
+            No inicie registros adicionales. Utilice las opciones de recuperación
+            disponibles en la plataforma para evitar duplicidad o inconsistencias en sus
+            datos.
+          </li>
+        </ol>
       `,
     },
     {
       id: 3,
       question: '¿Qué hago si no recuerdo mi correo electrónico?',
       answer: `
-<p>
-    Si olvidó el correo electrónico asociado a su cuenta, puede seguir las
-    recomendaciones a continuación:
-  </p>
-
-  <ol>
-    <li>
-      <strong>Buscar correos antiguos:</strong><br />
-      Intente localizar correos previos enviados por <strong>Cuenta Única</strong>
-      en sus bandejas de entrada, spam o archivos.
-    </li>
-
-    <li>
-      <strong>Intentar iniciar sesión:</strong><br />
-      Recuerde que puede iniciar sesión utilizando su
-      <strong>cédula o correo electrónico</strong> junto con su
-      <strong>contraseña</strong>.
-    </li>
-
-    <li>
-      <strong>Contactar a soporte técnico:</strong><br />
-      Si no logra identificar el correo asociado o no puede acceder a su cuenta,
-      envíe un correo a
-      <a href="mailto:ayudaogtic@ogtic.gob.do">ayudaogtic@ogtic.gob.do</a>
-      proporcionando su <strong>número de identificación personal</strong>
-      y una breve explicación del inconveniente.
-    </li>
-  </ol>
+        <p>
+          Si no recuerda el correo electrónico asociado a su
+          <strong> Cuenta Única Ciudadana</strong>, pruebe estas opciones antes de iniciar
+          un nuevo registro:
+        </p>
+        <ol>
+          <li>
+            <strong>Inicie sesión con su cédula:</strong><br />
+            La plataforma permite acceder con su cédula de identidad y electoral o con su
+            correo electrónico, junto con su contraseña.
+          </li>
+          <li>
+            <strong>Busque mensajes previos:</strong><br />
+            Revise sus bandejas de entrada, promociones, spam o correos archivados para
+            identificar mensajes enviados por Cuenta Única Ciudadana.
+          </li>
+          <li>
+            <strong>Use la recuperación de contraseña:</strong><br />
+            Si reconoce un correo posible, intente el proceso de recuperación. El código
+            solo llegará al correo asociado a la cuenta.
+          </li>
+          <li>
+            <strong>Si el inconveniente continúa:</strong><br />
+            Consulte los canales oficiales publicados por OGTIC o utilice las opciones de
+            ayuda disponibles dentro de la plataforma. No comparta datos personales por
+            canales no verificados.
+          </li>
+        </ol>
       `,
     },
     {
       id: 4,
       question: '¿Qué puedo hacer si no me llega el código de verificación?',
       answer: `
-        <p>Si no recibe el código de verificación:</p>
+        <p>
+          Si no recibe el código de verificación, realice estas validaciones:
+        </p>
         <ol>
-          <li>Revise su carpeta de <strong>Spam</strong> o <strong>Correo no deseado</strong>.</li>
-          <li>Espere unos minutos y solicite un nuevo código.</li>
-          <li>Verifique que su correo electrónico esté escrito correctamente.</li>
+          <li>
+            Revise las carpetas de <strong>Spam</strong>, <strong>Correo no deseado</strong>,
+            promociones o correos filtrados.
+          </li>
+          <li>
+            Espere unos minutos antes de solicitar un código nuevo. Pedir varios códigos
+            seguidos puede hacer que use un código anterior o ya vencido.
+          </li>
+          <li>
+            Confirme que el correo electrónico indicado sea el correcto y que tenga acceso
+            a esa bandeja.
+          </li>
+          <li>
+            Si está usando un correo institucional o corporativo, verifique si su
+            organización bloquea mensajes automáticos.
+          </li>
+          <li>
+            Cuando esté disponible, utilice la opción <strong>“Reenviar código”</strong>
+            desde la misma pantalla del proceso.
+          </li>
         </ol>
       `,
     },
@@ -144,37 +157,34 @@ export async function GET() {
       id: 5,
       question: '¿Cómo puedo reportar un error con mi cuenta?',
       answer: `
-<p>
-    Si experimenta algún inconveniente mientras realiza el proceso de registro
-    de su cuenta, puede reportarlo utilizando cualquiera de las siguientes opciones:
-  </p>
-
-  <ol>
-    <li>
-      <strong>Reportar desde la plataforma:</strong><br />
-      Durante el proceso de registro, puede utilizar el
-      <strong>botón flotante “Reportar”</strong> ubicado en el lado derecho de la pantalla.
-      Esta opción le permitirá notificar el inconveniente directamente desde la plataforma
-      en el momento en que ocurre.
-    </li>
-
-    <li>
-  <strong>Contactar a soporte técnico con la información requerida:</strong><br />
-  Envíe un correo electrónico a
-  <a href="mailto:ayudaogtic@ogtic.gob.do">ayudaogtic@ogtic.gob.do</a>
-  describiendo detalladamente el problema presentado.<br />
-
-  De ser posible, adjunte una <strong>captura de pantalla</strong> donde se muestre
-  claramente el error, e incluya en el mensaje su
-  <strong>número de cédula</strong> para facilitar una atención más rápida.
-</li>
-
-  </ol>
-
-  <p>
-    <em>Nota: Proporcionar información clara y completa permitirá al equipo de soporte
-    brindar una solución más ágil y efectiva.</em>
-  </p>
+        <p>
+          Si encuentra un error durante el registro, inicio de sesión o uso de su
+          <strong> Cuenta Única Ciudadana</strong>, repórtelo desde los mecanismos
+          disponibles en la plataforma.
+        </p>
+        <ol>
+          <li>
+            <strong>Use el botón “Reportar”:</strong><br />
+            Durante el proceso de registro puede aparecer un botón flotante
+            <strong>“Reportar”</strong>. Esta es la vía recomendada porque permite
+            registrar el inconveniente desde el punto exacto donde ocurre.
+          </li>
+          <li>
+            <strong>Describa el problema con claridad:</strong><br />
+            Indique qué estaba intentando hacer, en cuál paso ocurrió el error y qué
+            mensaje mostró la pantalla.
+          </li>
+          <li>
+            <strong>Incluya evidencia cuando la plataforma lo permita:</strong><br />
+            Una captura de pantalla puede ayudar a identificar el problema. Evite mostrar
+            información sensible si no es necesaria para explicar el caso.
+          </li>
+          <li>
+            <strong>Si no puede reportar desde la plataforma:</strong><br />
+            Consulte los canales oficiales de atención publicados por OGTIC y evite
+            compartir información personal en canales no verificados.
+          </li>
+        </ol>
       `,
       images: ['/faqs/6/6-step-1.png'],
     },
@@ -182,102 +192,68 @@ export async function GET() {
       id: 6,
       question: '¿Cómo puedo cambiar mi contraseña?',
       answer: `
-        <p>Para cambiar su contraseña actual:</p>
-<ol>
-    <li>
-      <strong>Iniciar sesión:</strong><br />
-      Acceda a la página de inicio de sesión en
-      <a href="https://mi.cuentaunica.gob.do/ui/login" target="_blank" rel="noopener noreferrer">
-        https://mi.cuentaunica.gob.do/ui/login
-      </a>
-      e inicie sesión con sus credenciales.
-    </li>
-
-    <li>
-      <strong>Acceder a la sección Contraseña:</strong><br />
-      Una vez dentro de la plataforma, en el menú lateral izquierdo,
-      seleccione la opción <strong>“Contraseña”</strong>.
-    </li>
-
-    <li>
-      <strong>Cambiar la contraseña:</strong><br />
-      Diríjase a la sección <strong>“Cambiar Contraseña”</strong>,
-      ingrese la <strong>nueva contraseña</strong> en el campo correspondiente.
-    </li>
-
-    <li>
-      <strong>Guardar los cambios:</strong><br />
-      Haga clic en el botón <strong>“Guardar”</strong> para aplicar
-      la actualización de su contraseña.
-    </li>
-  </ol>
+        <p>
+          Si conoce su contraseña actual, puede cambiarla desde la configuración de su
+          <strong> Cuenta Única Ciudadana</strong>.
+        </p>
+        <ol>
+          <li>
+            <strong>Inicie sesión:</strong><br />
+            Acceda a
+            <a href="https://mi.cuentaunica.gob.do/ui/login" target="_blank" rel="noopener noreferrer">
+              https://mi.cuentaunica.gob.do/ui/login
+            </a>
+            con sus credenciales.
+          </li>
+          <li>
+            <strong>Abra la sección de contraseña:</strong><br />
+            En el menú de configuración de la cuenta, seleccione la opción relacionada con
+            <strong> contraseña</strong>.
+          </li>
+          <li>
+            <strong>Defina la nueva contraseña:</strong><br />
+            Ingrese una contraseña nueva, segura y diferente a las que use en otros
+            servicios.
+          </li>
+          <li>
+            <strong>Guarde los cambios:</strong><br />
+            Presione <strong>“Guardar”</strong> y confirme que la plataforma muestre la
+            actualización como completada.
+          </li>
+        </ol>
       `,
       images: ['/faqs/7/7-step-1.png'],
     },
     {
       id: 7,
-      question: '¿Puedo agregar un segundo factor de autenticación?',
-      answer: `
-         <p>
-    Actualmente, la opción de <strong>segundo factor de autenticación (2FA)</strong>
-    <strong>no se encuentra disponible</strong> en la plataforma.
-  </p>
-
-  <p>
-    Sin embargo, nos encontramos trabajando en la implementación de este mecanismo
-    de seguridad para ofrecer una capa adicional de protección a su cuenta en el futuro.
-  </p>
-
-  <p>
-    Una vez habilitada esta funcionalidad, se notificará a los usuarios y se
-    proporcionarán instrucciones claras para su configuración.
-  </p>
-
-  <p>
-    <em>
-      Recomendamos mantenerse atento a las actualizaciones de la plataforma para
-      conocer la disponibilidad de nuevas funciones de seguridad.
-    </em>
-  </p>
-      `,
-    },
-    {
-      id: 8,
-      question: '¿Se puede eliminar una cuenta?',
+      question: '¿Puedo agregar métodos adicionales de autenticación?',
       answer: `
         <p>
-    Actualmente, <strong>no es posible eliminar una cuenta de manera manual</strong>
-    desde la plataforma.
-  </p>
-
-  <p>
-    Si desea solicitar la eliminación permanente de su cuenta, debe realizar la solicitud
-    a través de correo electrónico siguiendo los pasos a continuación:
-  </p>
-
-  <ol>
-    <li>
-      <strong>Redactar un correo electrónico:</strong><br />
-      Envíe un correo a la dirección
-      <a href="mailto:ayudaogtic@ogtic.gob.do">ayudaogtic@ogtic.gob.do</a>.
-    </li>
-
-    <li>
-      <strong>Explicar el motivo de la solicitud:</strong><br />
-      En el correo, indique claramente las razones por las cuales desea eliminar su cuenta.
-      Esto permitirá que el equipo de soporte evalúe su solicitud.
-    </li>
-
-    <li>
-      <strong>Esperar confirmación:</strong><br />
-      Una vez recibida la solicitud, el equipo correspondiente se pondrá en contacto
-      para informar sobre el estado del proceso.
-    </li>
-  </ol>
-
-  <p>
-    <em>Nota: La eliminación de la cuenta, una vez aprobada y ejecutada, es irreversible.</em>
-  </p>
+          Sí. <strong>Cuenta Única Ciudadana</strong> permite fortalecer el acceso con
+          métodos adicionales de autenticación cuando estén disponibles en la configuración
+          de su cuenta.
+        </p>
+        <ol>
+          <li>
+            <strong>Ingrese a su cuenta:</strong><br />
+            Acceda a la plataforma y abra la sección de configuración o seguridad.
+          </li>
+          <li>
+            <strong>Revise los métodos disponibles:</strong><br />
+            La plataforma mostrará las opciones que puede activar para su usuario. Estas
+            opciones pueden variar según el dispositivo, navegador o configuración
+            habilitada.
+          </li>
+          <li>
+            <strong>Siga las instrucciones en pantalla:</strong><br />
+            Complete la validación solicitada y confirme que el método quede registrado
+            antes de cerrar la sesión.
+          </li>
+        </ol>
+        <p>
+          Los métodos adicionales de autenticación ayudan a proteger su cuenta y reducen
+          el riesgo de acceso no autorizado.
+        </p>
       `,
     },
   ];

--- a/app/content/general-faq.ts
+++ b/app/content/general-faq.ts
@@ -1,0 +1,73 @@
+import { Questions } from '@/app/types';
+
+export const generalFaqQuestions: Questions[] = [
+  {
+    question: '¿Qué es la Cuenta Única Ciudadana?',
+    answer:
+      'La Cuenta Única Ciudadana es el mecanismo de autenticación digital que permite a las personas identificarse de forma segura ante los portales y aplicaciones del Estado dominicano que estén integrados al servicio. Con ella, la cédula de identidad y electoral funciona como identificador principal y el usuario administra sus credenciales desde una sola cuenta.',
+  },
+  {
+    question: '¿Qué problema busca resolver la Cuenta Única Ciudadana?',
+    answer:
+      'Busca reducir la necesidad de crear usuarios diferentes para cada servicio público digital. Al centralizar la autenticación, mejora la experiencia del ciudadano, disminuye el riesgo de cuentas abandonadas o contraseñas reutilizadas y ayuda a confirmar que quien accede a un servicio es la persona titular de la identidad.',
+  },
+  {
+    question: '¿Cómo se crea una Cuenta Única Ciudadana?',
+    answer:
+      'El registro inicia con la cédula de identidad y electoral. Luego se realiza una verificación de identidad, que puede incluir prueba de vida y comparación facial con la información disponible en la Junta Central Electoral. Finalmente, el ciudadano crea una contraseña segura y confirma su correo electrónico personal.',
+  },
+  {
+    question: '¿Para cuáles servicios me sirve esta cuenta?',
+    answer:
+      'La Cuenta Única Ciudadana sirve para acceder a los servicios digitales del Estado que se integren a la plataforma. Su adopción es progresiva, por lo que cada institución irá habilitando el acceso según sus propios sistemas y procesos.',
+  },
+  {
+    question:
+      '¿Puedo acceder a todos los servicios del Estado con este registro?',
+    answer:
+      'Ese es uno de los objetivos de la iniciativa, pero la disponibilidad depende de que cada institución gubernamental integre sus servicios digitales con Cuenta Única Ciudadana. Mientras avanza esa integración, la cuenta estará disponible en los portales y aplicaciones que ya la tengan habilitada.',
+  },
+  {
+    question:
+      '¿La Cuenta Única Ciudadana sustituye la cédula o el acta de nacimiento?',
+    answer:
+      'No. La Cuenta Única Ciudadana no sustituye la cédula de identidad y electoral ni el acta de nacimiento. Es un mecanismo de autenticación para servicios digitales. La cédula sigue siendo el documento oficial de identidad y la Junta Central Electoral es la entidad competente para su emisión y administración.',
+  },
+  {
+    question: '¿Por qué se valida mi cédula con la Junta Central Electoral?',
+    answer:
+      'La validación con la Junta Central Electoral permite confirmar que la identidad indicada corresponde a una persona registrada oficialmente. Esta verificación ayuda a proteger al ciudadano y a las instituciones frente a intentos de suplantación de identidad.',
+  },
+  {
+    question:
+      '¿Por qué se solicita acceso a la cámara durante la prueba de vida?',
+    answer:
+      'El acceso a la cámara se utiliza para completar la verificación de identidad dentro del proceso de registro. Es un permiso temporal del navegador para esa acción específica; no permite acceso remoto permanente a la cámara del dispositivo.',
+  },
+  {
+    question: '¿Qué tan segura es la plataforma?',
+    answer:
+      'Cuenta Única Ciudadana utiliza estándares reconocidos de autenticación y autorización, como OpenID Connect y OAuth 2.0, junto con prácticas de seguridad orientadas a proteger la identidad digital del ciudadano. También permite fortalecer el acceso con métodos adicionales de autenticación cuando estén disponibles para el usuario.',
+  },
+  {
+    question:
+      '¿Los métodos adicionales de autenticación dan acceso a mis dispositivos?',
+    answer:
+      'No. Los métodos como llaves de seguridad, autenticación desde el dispositivo o mecanismos sin contraseña se apoyan en estándares diseñados para validar el acceso sin entregar a la plataforma control sobre el equipo ni acceso libre a información biométrica del usuario.',
+  },
+  {
+    question: '¿Cuál es el marco legal relacionado con datos y seguridad?',
+    answer:
+      'La Cuenta Única Ciudadana se apoya en el marco normativo dominicano aplicable a identidad, protección de datos personales, interoperabilidad gubernamental y servicios digitales del Estado, incluyendo las disposiciones vigentes sobre datos personales, datos biométricos e intercambio seguro de información entre instituciones.',
+  },
+  {
+    question: '¿Cuenta Única Ciudadana ofrece APIs para instituciones?',
+    answer:
+      'Sí. Las instituciones que integren sus servicios pueden utilizar capacidades basadas en estándares como OpenID Connect y OAuth 2.0 para autenticación. La integración debe realizarse mediante los canales y lineamientos técnicos definidos por OGTIC.',
+  },
+  {
+    question: '¿Funcionará como una plataforma única de pagos?',
+    answer:
+      'No. Cuenta Única Ciudadana no es una plataforma de pagos. Su función principal es autenticar digitalmente al ciudadano. Sin embargo, puede facilitar el acceso seguro a servicios públicos digitales que incluyan procesos de pago dentro de los sistemas de cada institución.',
+  },
+];

--- a/app/questions/page.tsx
+++ b/app/questions/page.tsx
@@ -1,14 +1,9 @@
 import { Container } from '../components/container';
+import { generalFaqQuestions } from '../content/general-faq';
 import { Typography } from '../components/typography';
-import { Content, Questions } from '../types';
+import { Questions } from '../types';
 
-export default async function QuestionsPage() {
-  const contentUrl = process.env.CONTENT_JSON_URL as string;
-  const response = await fetch(contentUrl, {
-    cache: 'no-store',
-  });
-  const { questions }: Content = await response.json();
-
+export default function QuestionsPage() {
   return (
     <div style={{ padding: '60px 0' }}>
       <Container maxWidth="md">
@@ -16,7 +11,7 @@ export default async function QuestionsPage() {
           Preguntas frecuentes
         </Typography>
 
-        {questions.map((item: Questions, index) => (
+        {generalFaqQuestions.map((item: Questions, index) => (
           <div key={index}>
             <Typography color="primary" variant="h5" gutterBottom>
               {item?.question}


### PR DESCRIPTION
## Summary
- Updates the technical FAQ copy for Cuenta Única Ciudadana and removes the internal support email.
- Removes the account deletion FAQ until there is a confirmed public process.
- Moves the general FAQ content into the repo so `/questions` no longer depends on the remote content JSON for this section.

## Validation
- npm run lint
- npm run build
- rg "ayudaogtic@ogtic.gob.do|mailto:ayudaogtic"
- Browser smoke on `/questions` and `/technical-faqs`
